### PR TITLE
#11 - Code generation based on rules and JCodeModel

### DIFF
--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/data/ApiControllerMetadata.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/data/ApiControllerMetadata.java
@@ -12,15 +12,16 @@
  */
 package com.phoenixnap.oss.ramlapisync.data;
 
-import com.phoenixnap.oss.ramlapisync.naming.NamingHelper;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 import org.raml.model.Action;
 import org.raml.model.ActionType;
 import org.raml.model.Raml;
 import org.raml.model.Resource;
 
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import com.phoenixnap.oss.ramlapisync.naming.NamingHelper;
 
 
 /**
@@ -53,6 +54,10 @@ public class ApiControllerMetadata {
 	
 	public void addApiCall(Resource resource, ActionType actionType, Action action) {
 		apiCalls.add(new ApiMappingMetadata(this, resource, actionType, action));
+	}
+	
+	public void addApiCall(Resource resource, ActionType actionType, Action action, String responseContentType) {
+		apiCalls.add(new ApiMappingMetadata(this, resource, actionType, action, responseContentType));
 	}
 	
     public Set<ApiMappingMetadata> getApiCalls() {

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/data/ApiMappingMetadata.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/data/ApiMappingMetadata.java
@@ -44,6 +44,8 @@ public class ApiMappingMetadata {
 	Map<String, ApiBodyMetadata> responseBody = new LinkedHashMap<>();
 	Set<ApiParameterMetadata> pathVariables = null;
 	Set<ApiParameterMetadata> requestParameters = null;
+	
+	private String responseContentTypeFilter;
 
 	public ApiMappingMetadata(ApiControllerMetadata parent, Resource resource, ActionType actionType, Action action, String responseContentTypeFilter) {
 		super();
@@ -51,6 +53,8 @@ public class ApiMappingMetadata {
 		this.resource = resource;
 		this.actionType = actionType;
 		this.action = action;
+		
+		this.responseContentTypeFilter = responseContentTypeFilter;
 		parseRequest();
 		parseResponse(responseContentTypeFilter);
 
@@ -204,7 +208,11 @@ public class ApiMappingMetadata {
 	}
 
 	public String getName() {
-		return NamingHelper.getActionName(parent.getResource(), resource, action, actionType);
+		String name = NamingHelper.getActionName(parent.getResource(), resource, action, actionType);
+		if (responseContentTypeFilter != null) {
+			name += NamingHelper.convertContentTypeToQualifier(responseContentTypeFilter);
+		}
+		return name;
 	}
 
 	public String getProduces() {

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/data/ApiMappingMetadata.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/data/ApiMappingMetadata.java
@@ -135,29 +135,24 @@ public class ApiMappingMetadata {
 	}
 
 	private void parseResponse(String responseContentTypeFilter) {
-		if (action.getResponses() != null && !action.getResponses().isEmpty()) {
-			for (Entry<String, Response> responses : action.getResponses().entrySet()) {
-				Response response = responses.getValue();
+		Response response = ResourceParser.getSuccessfulResponse(action);
 
-				if ("200".equals(responses.getKey()) && response.getBody() != null && !response.getBody().isEmpty()) {
-					for (Entry<String, MimeType> body : response.getBody().entrySet()) {
-						if (responseContentTypeFilter == null || body.getKey().equals(responseContentTypeFilter)) {
-							if (body.getKey().toLowerCase().contains("json")) { //if we have a json type we need to return an object
-								// Continue here!
-								String schema = body.getValue().getSchema();
-								if (StringUtils.hasText(schema)) {
-									
-									ApiBodyMetadata responseBody = SchemaHelper.mapSchemaToPojo(parent.getDocument(), schema,
-											parent.getBasePackage() + ".model", StringUtils.capitalize(getName()) + "Response");
-									if (responseBody != null) {
-										this.responseBody.put(body.getKey(), responseBody);
-									}
-								}
+		if (response != null && response.getBody() != null && !response.getBody().isEmpty()) {
+			for (Entry<String, MimeType> body : response.getBody().entrySet()) {
+				if (responseContentTypeFilter == null || body.getKey().equals(responseContentTypeFilter)) {
+					if (body.getKey().toLowerCase().contains("json")) { //if we have a json type we need to return an object
+						// Continue here!
+						String schema = body.getValue().getSchema();
+						if (StringUtils.hasText(schema)) {
+							
+							ApiBodyMetadata responseBody = SchemaHelper.mapSchemaToPojo(parent.getDocument(), schema,
+									parent.getBasePackage() + ".model", StringUtils.capitalize(getName()) + "Response");
+							if (responseBody != null) {
+								this.responseBody.put(body.getKey(), responseBody);
 							}
 						}
 					}
 				}
-
 			}
 		}
 	}

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlGenerator.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlGenerator.java
@@ -280,6 +280,7 @@ public class RamlGenerator {
 	/**
 	 * Takes the absolute path and gets the Raml file to be created
 	 *
+	 * @param path The path for the raml file to be saved in
 	 * @return raml file to be generated
 	 */
 	public File getRamlOutputFile(String path) {

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlParser.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlParser.java
@@ -126,7 +126,14 @@ public class RamlParser {
 		//extract actions for this resource
 		if (resource.getActions() != null && !resource.getActions().isEmpty()) {			
 			for (Entry<ActionType, Action> childResource : resource.getActions().entrySet()) {
-				controller.addApiCall(resource, childResource.getKey(), childResource.getValue());
+				//if we have multiple response types in the raml, this should produce different calls
+				if (childResource.getValue().hasBody() && childResource.getValue().getBody().size() > 1) {
+					for (String responseType : childResource.getValue().getBody().keySet()) {
+						controller.addApiCall(resource, childResource.getKey(), childResource.getValue(), responseType);
+					}
+				} else {
+					controller.addApiCall(resource, childResource.getKey(), childResource.getValue());
+				}
 			}
 		}
 		if (resource.getResources() != null &&  !resource.getResources().isEmpty()) {

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlParser.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlParser.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.phoenixnap.oss.ramlapisync.data.ApiControllerMetadata;
+import com.phoenixnap.oss.ramlapisync.parser.ResourceParser;
 
 
 /**
@@ -142,11 +143,11 @@ public class RamlParser {
 				Response response = null;
 				
 				if (childResource.getValue().getResponses() != null) {
-					response = childResource.getValue().getResponses().get("200");
+					response = ResourceParser.getSuccessfulResponse(childResource.getValue());
 				}
 				
 				if (seperateMethodsByContentType && response != null && response.hasBody() && response.getBody().size() > 1) {
-						for (String responseType : childResource.getValue().getResponses().get("200").getBody().keySet()) {
+						for (String responseType : response.getBody().keySet()) {
 							controller.addApiCall(resource, childResource.getKey(), childResource.getValue(), responseType);
 						}
 					

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlParser.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlParser.java
@@ -52,6 +52,11 @@ public class RamlParser {
 	 * The start URL that every controller should be prefixed with
 	 */
 	private String startUrl = "";
+	
+	/**
+	 * If set to true, we will generate seperate methods for different content types in the RAML
+	 */
+	protected boolean seperateMethodsByContentType = false;
 
 	public RamlParser (String basePackage) {
 		this.basePackage = basePackage;
@@ -60,6 +65,11 @@ public class RamlParser {
 	public RamlParser(String basePackage, String startUrl) {
 		this(basePackage);
 		this.startUrl = startUrl;
+	}
+	
+	public RamlParser(String basePackage, String startUrl, boolean seperateMethodsByContentType) {
+		this(basePackage, startUrl);
+		this.seperateMethodsByContentType = seperateMethodsByContentType;
 	}
 
 	/**
@@ -135,7 +145,7 @@ public class RamlParser {
 					response = childResource.getValue().getResponses().get("200");
 				}
 				
-				if (response != null && response.hasBody() && response.getBody().size() > 1) {
+				if (seperateMethodsByContentType && response != null && response.hasBody() && response.getBody().size() > 1) {
 						for (String responseType : childResource.getValue().getResponses().get("200").getBody().keySet()) {
 							controller.addApiCall(resource, childResource.getKey(), childResource.getValue(), responseType);
 						}

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlParser.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlParser.java
@@ -12,18 +12,20 @@
  */
 package com.phoenixnap.oss.ramlapisync.generation;
 
-import com.phoenixnap.oss.ramlapisync.data.ApiControllerMetadata;
+import java.util.LinkedHashSet;
+import java.util.Map.Entry;
+import java.util.Set;
+
 import org.raml.model.Action;
 import org.raml.model.ActionType;
 import org.raml.model.Raml;
 import org.raml.model.Resource;
+import org.raml.model.Response;
 import org.raml.parser.visitor.RamlDocumentBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.LinkedHashSet;
-import java.util.Map.Entry;
-import java.util.Set;
+import com.phoenixnap.oss.ramlapisync.data.ApiControllerMetadata;
 
 
 /**
@@ -127,10 +129,17 @@ public class RamlParser {
 		if (resource.getActions() != null && !resource.getActions().isEmpty()) {			
 			for (Entry<ActionType, Action> childResource : resource.getActions().entrySet()) {
 				//if we have multiple response types in the raml, this should produce different calls
-				if (childResource.getValue().hasBody() && childResource.getValue().getBody().size() > 1) {
-					for (String responseType : childResource.getValue().getBody().keySet()) {
-						controller.addApiCall(resource, childResource.getKey(), childResource.getValue(), responseType);
-					}
+				Response response = null;
+				
+				if (childResource.getValue().getResponses() != null) {
+					response = childResource.getValue().getResponses().get("200");
+				}
+				
+				if (response != null && response.hasBody() && response.getBody().size() > 1) {
+						for (String responseType : childResource.getValue().getResponses().get("200").getBody().keySet()) {
+							controller.addApiCall(resource, childResource.getKey(), childResource.getValue(), responseType);
+						}
+					
 				} else {
 					controller.addApiCall(resource, childResource.getKey(), childResource.getValue());
 				}

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlSpring4DecoratorGenerator.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlSpring4DecoratorGenerator.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.phoenixnap.oss.ramlapisync.generation;
 
 import com.phoenixnap.oss.ramlapisync.data.ApiControllerMetadata;

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlSpring4DecoratorGenerator.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlSpring4DecoratorGenerator.java
@@ -33,14 +33,14 @@ import java.util.List;
  *
  * // 2. A Decorator that implements the Controller Interface
  * // and delegates to another instance of a class implementing the very same controller interface.
- * @RestController
- * @RequestMapping("/people")
+ * {@literal @}RestController
+ * {@literal @}RequestMapping("/people")
  * class PeopleControllerDecorator implements PeopleController {
  *
- *     @Autowired
+ *     {@literal @}Autowired
  *     PeopleController peopleControllerDelegate;
  *
- *     @RequestMapping(value="", method=RequestMethod.GET)
+ *     {@literal @}RequestMapping(value="", method=RequestMethod.GET)
  *     public ResponseEntity getPeople() {
  *         return this.peopleControllerDelegate.getPeople();
  *     }

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlSpring4InterfaceOnlyGenerator.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlSpring4InterfaceOnlyGenerator.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.phoenixnap.oss.ramlapisync.generation;
 
 import com.phoenixnap.oss.ramlapisync.data.ApiControllerMetadata;

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlSpring4InterfaceOnlyGenerator.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/RamlSpring4InterfaceOnlyGenerator.java
@@ -26,10 +26,10 @@ import java.util.List;
  * A raml endpoint called /people for example would lead to the following interface only:
  *
  * // 1. Controller Interface
- * @RestController
- * @RequestMapping("/people")
+ * {@literal @}@RestController
+ * {@literal @}@RequestMapping("/people")
  * interface PeopleController {
- *     @RequestMapping(value="", method=RequestMethod.GET)
+ *     {@literal @}@RequestMapping(value="", method=RequestMethod.GET)
  *     ResponseEntity getPeople();
  * }
  *

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/serialize/ApiControllerMetadataSerializer.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/serialize/ApiControllerMetadataSerializer.java
@@ -1,7 +1,22 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.phoenixnap.oss.ramlapisync.generation.serialize;
 
 /**
+ * Implementations of this interface will serialize Controllers descibed via ApiControllerMetadata into a string representation that can be stored
+ * 
  * @author armin.weisser
+ * @since 0.3.1
  */
 public interface ApiControllerMetadataSerializer {
 

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/serialize/Spring4ControllerInterfaceSerializer.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/serialize/Spring4ControllerInterfaceSerializer.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.phoenixnap.oss.ramlapisync.generation.serialize;
 
 import com.phoenixnap.oss.ramlapisync.data.ApiBodyMetadata;
@@ -6,7 +18,10 @@ import com.phoenixnap.oss.ramlapisync.data.ApiMappingMetadata;
 import com.phoenixnap.oss.ramlapisync.data.ApiParameterMetadata;
 
 /**
+ * Serializer that will create a java interface without any Spring MVC Annotations
+ * 
  * @author armin.weisser
+ * @since 0.3.1
  */
 public class Spring4ControllerInterfaceSerializer extends Spring4ControllerSerializer {
 

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/serialize/Spring4ControllerInterfaceWithAnnotationsSerializer.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/serialize/Spring4ControllerInterfaceWithAnnotationsSerializer.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.phoenixnap.oss.ramlapisync.generation.serialize;
 
 import com.phoenixnap.oss.ramlapisync.data.ApiBodyMetadata;
@@ -5,7 +17,10 @@ import com.phoenixnap.oss.ramlapisync.data.ApiControllerMetadata;
 import com.phoenixnap.oss.ramlapisync.data.ApiMappingMetadata;
 
 /**
+ * Serializer that will create a JAva interface annotated with Spring MVC annotations
+ * 
  * @author armin.weisser
+ * @since 0.3.1
  */
 public class Spring4ControllerInterfaceWithAnnotationsSerializer extends Spring4ControllerSerializer {
 

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/serialize/Spring4ControllerSerializer.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/serialize/Spring4ControllerSerializer.java
@@ -304,7 +304,7 @@ public class Spring4ControllerSerializer implements ApiControllerMetadataSeriali
      *
      * @param parameterMetadataList values to iterator
      * @param mappingFunction a mapping function
-     * @param <T>
+     * @param <T> Any class
      * @return a ',' seperated serialization of parameterMetadataList values mapped by the mapping function.
      */
     protected <T> String generateCommaSeperatedParameters(List<T> parameterMetadataList, Function<T, String> mappingFunction) {

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/serialize/Spring4DecoratorSerializer.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/generation/serialize/Spring4DecoratorSerializer.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.phoenixnap.oss.ramlapisync.generation.serialize;
 
 import com.phoenixnap.oss.ramlapisync.data.ApiBodyMetadata;
@@ -5,7 +17,11 @@ import com.phoenixnap.oss.ramlapisync.data.ApiControllerMetadata;
 import com.phoenixnap.oss.ramlapisync.data.ApiMappingMetadata;
 
 /**
+ * Serializer that will create a spring controller, and delegate calls to an Interface (generated seperately) which requires
+ * an implementation to be provided at runtime (@Autowired) 
+ * 
  * @author armin.weisser
+ * @since 0.3.1
  */
 public class Spring4DecoratorSerializer extends Spring4ControllerSerializer {
 

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/parser/ResourceParser.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/parser/ResourceParser.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
 import org.raml.model.Action;
@@ -30,6 +31,7 @@ import org.raml.model.Response;
 import org.raml.model.parameter.QueryParameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import com.phoenixnap.oss.ramlapisync.data.ApiParameterMetadata;
@@ -318,7 +320,9 @@ public abstract class ResourceParser {
 		jsonType.setSchema(SchemaHelper.convertClassToJsonSchema(method.getGenericReturnType(), responseComment,
 				javaDocs.getJavaDoc(method.getReturnType())));
 
-		response.setBody(Collections.singletonMap(mime, jsonType));
+		LinkedHashMap<String, MimeType> body = new LinkedHashMap<>();
+		body.put(mime, jsonType);
+		response.setBody(body);
 		if (StringUtils.hasText(responseComment)) {
 			response.setDescription(responseComment);
 		} else {
@@ -327,6 +331,45 @@ public abstract class ResourceParser {
 		return response;
 	}
 
+	/**
+	 * Merges together existing actions. At present we are doing the following:
+	 * 
+	 * - Add Response bodies from the new to existing
+	 * 
+	 * TODO Other operations that we should consider. Not adding these until an actual usecase crops up.
+	 * - Merging Descriptions?
+	 * - Copying over Request Data?
+	 * - Copying over other responses?
+	 * 
+	 * @param existingAction
+	 * @param newAction
+	 */
+	protected void mergeActions (Action existingAction, Action newAction) {
+		Response existingSuccessfulResponse = getSuccessfulResponse(existingAction);
+		Response successfulResponse = getSuccessfulResponse(newAction);
+
+		if (existingSuccessfulResponse != null && existingSuccessfulResponse.hasBody() && successfulResponse != null && successfulResponse.hasBody()) {
+			for (Entry<String, MimeType> body : successfulResponse.getBody().entrySet()) {
+				existingSuccessfulResponse.getBody().putIfAbsent(body.getKey(), body.getValue());
+			}
+		}
+	}
+	
+	/**
+	 * Gets the successful response from an action (200 or 201)
+	 * @param action
+	 * @return The Successful response or null if not found
+	 */
+	public static Response getSuccessfulResponse(Action action) {
+		String[] successfulResponses = new String[] {"200", "201"};
+		for (String code : successfulResponses) {
+			if (action != null && !CollectionUtils.isEmpty(action.getResponses()) && action.getResponses().containsKey(code)) {
+				return action.getResponses().get(code);
+			}
+		}
+		return null;
+	}
+	
 	/**
 	 * 
 	 * Extracts class information from a (believe it or not) java class as well as the contained methods.

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/parser/ResourceParser.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/parser/ResourceParser.java
@@ -63,6 +63,7 @@ public abstract class ResourceParser {
 	protected String version;
 
 	protected String defaultMediaType;
+	
 
 	public ResourceParser(File javaDocPath, String version, String defaultMediaType) {
 		this.version = version;

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/parser/ResourceParser.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/parser/ResourceParser.java
@@ -15,7 +15,6 @@ package com.phoenixnap.oss.ramlapisync.parser;
 import java.io.File;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -78,8 +77,7 @@ public abstract class ResourceParser {
 	 * @param clazz
 	 * @return
 	 */
-	private List<Resource> getMethodsFromService(Class<?> clazz, JavaDocStore javaDoc, Resource parentResource) {
-		List<Resource> resources = new ArrayList<>();
+	private void getMethodsFromService(Class<?> clazz, JavaDocStore javaDoc, Resource parentResource) {
 		try {
 			for (Method method : clazz.getMethods()) {
 				if (!IGNORE_METHOD_REGEX.matcher(method.getName()).matches() && shouldAddMethodToApi(method)) {
@@ -89,7 +87,6 @@ public abstract class ResourceParser {
 		} catch (NoClassDefFoundError nEx) {
 			logger.error("Unable to get methods - skipping class " + clazz, nEx);
 		}
-		return resources;
 	}
 
 	/**
@@ -349,17 +346,10 @@ public abstract class ResourceParser {
 			resource.setDescription(comment);
 		}
 
-		List<Resource> methodsFromService = getMethodsFromService(clazz, javaDoc, resource);
-		for (Resource cResource : methodsFromService) {
-			String relativeUri = cResource.getRelativeUri();
-			if (resource.getResources().containsKey(relativeUri)) {
-				resource.getResource(relativeUri).getActions().putAll(cResource.getActions());
-			} else {
-				cResource.setParentResource(resource);
-				cResource.setParentUri(resource.getUri());
-				resource.getResources().put(relativeUri, cResource);
-			}
-		}
+		
+		//Append stuff to the parent resource
+		getMethodsFromService(clazz, javaDoc, resource);
+		
 
 		return resource;
 	}

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/parser/SpringMvcResourceParser.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/parser/SpringMvcResourceParser.java
@@ -541,10 +541,19 @@ public class SpringMvcResourceParser extends ResourceParser {
 			}
 			action.setResource(actionTargetResource);
 			action.setType(apiAction);
-			actionTargetResource.getActions().putIfAbsent(apiAction, action);
+			if (actionTargetResource.getActions().containsKey(apiAction)) {
+				//merge action
+				Action existingAction = actionTargetResource.getActions().get(apiAction);
+				mergeActions(existingAction, action);
+				
+			} else {
+				actionTargetResource.getActions().put(apiAction, action);
+			}
 		}
 
 	}
+	
+	
 
 	private String cleanPathVariableRegex(String partialUrl) {
 		if (partialUrl.startsWith("{") && partialUrl.endsWith("}") && partialUrl.contains(":")) {

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/verification/checkers/ActionContentTypeChecker.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/verification/checkers/ActionContentTypeChecker.java
@@ -55,7 +55,7 @@ public class ActionContentTypeChecker
 		Set<Issue> warnings = new LinkedHashSet<>();
 		Issue issue;
 
-		// Only apply this checker in the contract
+		// Only apply this checker in the source
 		if (location.equals(IssueLocation.CONTRACT)) {
 			return new Pair<>(warnings, errors);
 		}

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/verification/checkers/ActionContentTypeChecker.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/verification/checkers/ActionContentTypeChecker.java
@@ -78,22 +78,21 @@ public class ActionContentTypeChecker implements RamlActionVisitorCheck {
 		}
 		
 		//Now the response
-		if (reference.getResponses() != null && !reference.getResponses().isEmpty() && reference.getResponses().containsKey("200")) {
-			//successful response
-			Response response = reference.getResponses().get("200");
-			if (response.getBody() != null && !response.getBody().isEmpty()) {
-				if (target.getResponses() == null || target.getResponses().isEmpty() || target.getResponses().get("200") == null) {
-					issue = new Issue(maxSeverity, location, IssueType.MISSING, RESPONSE_BODY_MISSING, reference.getResource(), reference);
-					RamlCheckerResourceVisitorCoordinator.addIssue(errors, warnings, issue, RESPONSE_BODY_MISSING);
-				} else {
-					//successful response
-					Response targetResponse = target.getResponses().get("200");
-					for (String key : response.getBody().keySet()) {
-						logger.debug("Processing key {}.", key);
-						if (!targetResponse.getBody().containsKey(key) && !targetResponse.getBody().containsKey(ResourceParser.CATCH_ALL_MEDIA_TYPE)) {
-							issue = new Issue(maxSeverity, location, IssueType.MISSING, RESPONSE_BODY_MISSING, reference.getResource(), reference);
-							RamlCheckerResourceVisitorCoordinator.addIssue(errors, warnings, issue, RESPONSE_BODY_MISSING + " " + key);
-						}
+		Response response = ResourceParser.getSuccessfulResponse(reference);
+		//successful response
+		if (response != null && response.getBody() != null && !response.getBody().isEmpty()) {
+			Response targetResponse = ResourceParser.getSuccessfulResponse(target);
+			
+			if (targetResponse == null) {
+				issue = new Issue(maxSeverity, location, IssueType.MISSING, RESPONSE_BODY_MISSING, reference.getResource(), reference);
+				RamlCheckerResourceVisitorCoordinator.addIssue(errors, warnings, issue, RESPONSE_BODY_MISSING);
+			} else {
+				//successful response
+				for (String key : response.getBody().keySet()) {
+					logger.debug("Processing key {}.", key);
+					if (!targetResponse.getBody().containsKey(key) && !targetResponse.getBody().containsKey(ResourceParser.CATCH_ALL_MEDIA_TYPE)) {
+						issue = new Issue(maxSeverity, location, IssueType.MISSING, RESPONSE_BODY_MISSING, reference.getResource(), reference);
+						RamlCheckerResourceVisitorCoordinator.addIssue(errors, warnings, issue, RESPONSE_BODY_MISSING + " " + key);
 					}
 				}
 			}

--- a/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/verification/checkers/ActionContentTypeChecker.java
+++ b/springmvc-raml-parser/src/main/java/com/phoenixnap/oss/ramlapisync/verification/checkers/ActionContentTypeChecker.java
@@ -1,16 +1,14 @@
 /*
  * Copyright 2002-2016 the original author or authors.
- * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
 package com.phoenixnap.oss.ramlapisync.verification.checkers;
+
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -29,6 +27,8 @@ import com.phoenixnap.oss.ramlapisync.verification.IssueSeverity;
 import com.phoenixnap.oss.ramlapisync.verification.IssueType;
 import com.phoenixnap.oss.ramlapisync.verification.RamlActionVisitorCheck;
 
+
+
 /**
  * A checker that will check request and response media types.
  * 
@@ -36,8 +36,9 @@ import com.phoenixnap.oss.ramlapisync.verification.RamlActionVisitorCheck;
  * @since 0.1.0
  *
  */
-public class ActionContentTypeChecker implements RamlActionVisitorCheck {
-	
+public class ActionContentTypeChecker
+		implements RamlActionVisitorCheck {
+
 	public static String REQUEST_BODY_MISSING = "Body required but not found in target";
 	public static String RESPONSE_BODY_MISSING = "Response Body required but not found in target";
 	/**
@@ -45,65 +46,72 @@ public class ActionContentTypeChecker implements RamlActionVisitorCheck {
 	 */
 	protected static final Logger logger = LoggerFactory.getLogger(ActionContentTypeChecker.class);
 
+
+
 	@Override
 	public Pair<Set<Issue>, Set<Issue>> check(ActionType name, Action reference, Action target, IssueLocation location, IssueSeverity maxSeverity) {
 		logger.debug("Checking action " + name);
 		Set<Issue> errors = new LinkedHashSet<>();
 		Set<Issue> warnings = new LinkedHashSet<>();
 		Issue issue;
-		
-		//Only apply this checker in the contract
+
+		// Only apply this checker in the contract
 		if (location.equals(IssueLocation.CONTRACT)) {
 			return new Pair<>(warnings, errors);
 		}
-		
-		//Request First
-		//First lets check if we have defined a request media type.
+
+		// Request First
+		// First lets check if we have defined a request media type.
 		if (reference.getBody() != null && !reference.getBody().isEmpty()) {
-			//lets check if we have a catch all on the implementation
+			// lets check if we have a catch all on the implementation
 			if (target.getBody() == null || target.getBody().isEmpty()) {
 				issue = new Issue(maxSeverity, location, IssueType.MISSING, REQUEST_BODY_MISSING, reference.getResource(), reference);
 				RamlCheckerResourceVisitorCoordinator.addIssue(errors, warnings, issue, REQUEST_BODY_MISSING);
 			}
-			if(target.getBody() != null && target.getBody().containsKey(ResourceParser.CATCH_ALL_MEDIA_TYPE)) {
-				//catch all will be able to handle any request.
-			} else {
+			if (target.getBody() != null && target.getBody().containsKey(ResourceParser.CATCH_ALL_MEDIA_TYPE)) {
+				// catch all will be able to handle any request.
+			}
+			else {
 				for (String key : reference.getBody().keySet()) {
 					if (!target.getBody().containsKey(key)) {
 						issue = new Issue(maxSeverity, location, IssueType.MISSING, REQUEST_BODY_MISSING, reference.getResource(), reference);
 						RamlCheckerResourceVisitorCoordinator.addIssue(errors, warnings, issue, REQUEST_BODY_MISSING + " " + key);
 					}
 				}
-			}			
+			}
 		}
-		
-		//Now the response
+
+		// Now the response
 		if (reference.getResponses() != null && !reference.getResponses().isEmpty() && reference.getResponses().containsKey("200")) {
-			//successful response
+			// successful response
 			Response response = reference.getResponses().get("200");
 			if (response.getBody() != null && !response.getBody().isEmpty()) {
 				if (target.getResponses() == null || target.getResponses().isEmpty() || target.getResponses().get("200") == null) {
 					issue = new Issue(maxSeverity, location, IssueType.MISSING, RESPONSE_BODY_MISSING, reference.getResource(), reference);
 					RamlCheckerResourceVisitorCoordinator.addIssue(errors, warnings, issue, RESPONSE_BODY_MISSING);
-				} else {
-					//successful response
+				}
+				else {
+					// successful response
 					Response targetResponse = target.getResponses().get("200");
+					boolean found = false;
 					for (String key : response.getBody().keySet()) {
 						logger.debug("Processing key {}.", key);
-						if (!targetResponse.getBody().containsKey(key) && !targetResponse.getBody().containsKey(ResourceParser.CATCH_ALL_MEDIA_TYPE)) {
-							issue = new Issue(maxSeverity, location, IssueType.MISSING, RESPONSE_BODY_MISSING, reference.getResource(), reference);
-							RamlCheckerResourceVisitorCoordinator.addIssue(errors, warnings, issue, RESPONSE_BODY_MISSING + " " + key);
+						if (targetResponse.getBody().containsKey(key)) {
+							found = true;
+							break;
 						}
+					}
+					if (!found && !targetResponse.getBody().containsKey(ResourceParser.CATCH_ALL_MEDIA_TYPE)) {
+						issue = new Issue(maxSeverity, location, IssueType.MISSING, RESPONSE_BODY_MISSING, reference.getResource(), reference);
+						RamlCheckerResourceVisitorCoordinator.addIssue(errors, warnings, issue, RESPONSE_BODY_MISSING + " " + response.getBody().values());
 					}
 				}
 			}
-				
+
 		}
-			
+
 		return new Pair<>(warnings, errors);
 	}
-	
 
-	
-	
+
 }

--- a/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/NamingHelperTest.java
+++ b/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/NamingHelperTest.java
@@ -72,5 +72,20 @@ public class NamingHelperTest {
 		assertEquals("Should resolve property if available", "/one:8080/two/3/four/five/", NamingHelper.resolveProperties("/one:8080/two/${three}/four/${five}/"));
 		assertEquals("All of the above", "/one:8080/two/3/four/five/", NamingHelper.resolveProperties("/one:8080/two/${three}/${four:four}/${five}/"));
 	}
+	
+	@Test
+	public void test_convertTypeToQualifier_Success() {
+		assertEquals("Should deal with simple standards cleanly", "AsJson", NamingHelper.convertContentTypeToQualifier("application/json"));
+		assertEquals("Should deal with simple standards cleanly", "AsBinary", NamingHelper.convertContentTypeToQualifier("application/octet-stream"));
+		assertEquals("Should deal with simple standards cleanly", "AsText", NamingHelper.convertContentTypeToQualifier("text/plain"));
+		assertEquals("Should deal with simple standards cleanly", "AsText", NamingHelper.convertContentTypeToQualifier("text/html"));
+		
+		assertEquals("Should deal extract versions", "V1", NamingHelper.convertContentTypeToQualifier("application/v1+json"));
+		assertEquals("Should deal extract versions", "V1", NamingHelper.convertContentTypeToQualifier("application/asdasdasdv1asdsad+json"));
+		assertEquals("Should deal extract versions", "V1_2", NamingHelper.convertContentTypeToQualifier("application/asdasdasdv1.2asdsad+json"));
+		
+		assertEquals("Should deal extract versions", "_StuffAsJson", NamingHelper.convertContentTypeToQualifier("application/stuff+json"));
+		
+	}
 
 }

--- a/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/RamlVerifierTest.java
+++ b/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/RamlVerifierTest.java
@@ -1,16 +1,14 @@
 /*
  * Copyright 2002-2016 the original author or authors.
- * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
 package test.phoenixnap.oss.plugin.naming;
+
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -23,6 +21,7 @@ import org.junit.Test;
 import org.raml.model.Raml;
 
 import test.phoenixnap.oss.plugin.naming.testclasses.ContentTypeTestController;
+import test.phoenixnap.oss.plugin.naming.testclasses.MultiContentTypeTestController;
 import test.phoenixnap.oss.plugin.naming.testclasses.ParamTestController;
 import test.phoenixnap.oss.plugin.naming.testclasses.ParamTestControllerDowngradeToWarning;
 import test.phoenixnap.oss.plugin.naming.testclasses.ParamTestControllerPostMissing;
@@ -49,6 +48,8 @@ import com.phoenixnap.oss.ramlapisync.verification.checkers.ActionQueryParameter
 import com.phoenixnap.oss.ramlapisync.verification.checkers.ActionResponseBodySchemaChecker;
 import com.phoenixnap.oss.ramlapisync.verification.checkers.ResourceExistenceChecker;
 
+
+
 /**
  * Unit tests for the RamlVerifier class and associated Checkers
  * 
@@ -60,271 +61,311 @@ public class RamlVerifierTest {
 
 	SpringMvcResourceParser parser = new SpringMvcResourceParser(null, "0.0.1", ResourceParser.CATCH_ALL_MEDIA_TYPE, false);
 	RamlGenerator generator = new RamlGenerator(parser);
-	
+
+
+
 	@Test
 	public void test_ResourceExistenceChecker_Success() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-simple.raml");
-		Class<?>[] classesToGenerate = new Class[] {VerifierTestController.class, SecondVerifierTestController.class};
+		Class<?>[] classesToGenerate = new Class[] { VerifierTestController.class, SecondVerifierTestController.class };
 		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-		
+
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.singletonList(new ResourceExistenceChecker()), null, null);
 		assertFalse("Check that there are no errors and implementation matches raml", verifier.hasErrors());
 		assertFalse("Check that there are no warnings and implementation matches raml", verifier.hasWarnings());
-		
+
 	}
-	
+
+
 	@Test
 	public void test_ResourceExistenceChecker_DuplicateCommand() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-duplicatecommand.raml");
-		Class<?>[] classesToGenerate = new Class[] {StyleCheckResourceDuplicateCommand.class, StyleCheckResourceDuplicateCommandSecond.class};
+		Class<?>[] classesToGenerate = new Class[] { StyleCheckResourceDuplicateCommand.class, StyleCheckResourceDuplicateCommandSecond.class };
 		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-		
+
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.singletonList(new ResourceExistenceChecker()), null, null);
 		assertFalse("Check that there are no errors and implementation matches raml", verifier.hasErrors());
 		assertFalse("Check that there are no warnings and implementation matches raml", verifier.hasWarnings());
-		
+
 	}
-	
+
+
 	@Test
 	public void test_ActionQueryParameterChecker_Success() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-queryparam-success.raml");
-		Class<?>[] classesToGenerate = new Class[] {ParamTestController.class};
+		Class<?>[] classesToGenerate = new Class[] { ParamTestController.class };
 		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-		
+
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionQueryParameterChecker()), null);
 		assertFalse("Check that there are no errors and implementation matches raml", verifier.hasErrors());
 		assertFalse("Check that there are no warnings and implementation matches raml", verifier.hasWarnings());
-		
+
 	}
-	
+
+
 	@Test
 	public void test_ActionContentTypeChecker_Success() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-contenttype-success.raml");
-		Class<?>[] classesToGenerate = new Class[] {ContentTypeTestController.class};
+		Class<?>[] classesToGenerate = new Class[] { ContentTypeTestController.class };
 		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-		
+
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionContentTypeChecker()), null);
 		assertFalse("Check that there are no errors and implementation matches raml", verifier.hasErrors());
 		assertFalse("Check that there are no warnings and implementation matches raml", verifier.hasWarnings());
-		
+
 	}
-	
+
+
+	@Test
+	public void test_ActionMultiContentTypeChecker_Success() {
+		Raml published = RamlVerifier.loadRamlFromFile("test-multicontenttype-success.raml");
+		Class<?>[] classesToGenerate = new Class[] { MultiContentTypeTestController.class };
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+
+		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionContentTypeChecker()), null);
+		assertFalse("Check that there are no errors and implementation matches raml", verifier.hasErrors());
+		assertFalse("Check that there are no warnings and implementation matches raml", verifier.hasWarnings());
+
+	}
+
+
+	@Test
+	public void test_ActionMultiContentTypeChecker_ExtraContentTypeInController() {
+		Raml published = RamlVerifier.loadRamlFromFile("test-multicontenttype-missingcontent.raml");
+		Class<?>[] classesToGenerate = new Class[] { MultiContentTypeTestController.class };
+		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
+
+		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionContentTypeChecker()), null);
+		assertTrue("Check that there are no errors and implementation matches raml", verifier.hasErrors());
+		assertFalse("Check that there are no warnings and implementation matches raml", verifier.hasWarnings());
+
+	}
+
+
 	@Test
 	public void test_ActionResponseBodySchemaChecker_Success() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-responsebody-success.raml");
-		Class<?>[] classesToGenerate = new Class[] {ResponseBodyTestController.class};
+		Class<?>[] classesToGenerate = new Class[] { ResponseBodyTestController.class };
 		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-		
+
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionResponseBodySchemaChecker()), null);
 		assertFalse("Check that there are no errors and implementation matches raml", verifier.hasErrors());
 		assertFalse("Check that there are no warnings and implementation matches raml", verifier.hasWarnings());
-		
+
 	}
-	
+
+
 	@Test
 	public void test_ActionContentTypeChecker_WarningDifferentType() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-responsebody-differenttype.raml");
-		Class<?>[] classesToGenerate = new Class[] {ResponseBodyTestController.class};
+		Class<?>[] classesToGenerate = new Class[] { ResponseBodyTestController.class };
 		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-		
+
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionResponseBodySchemaChecker()), null);
 		assertFalse("Check that there are errors", verifier.hasErrors());
 		assertTrue("Check that there are warnings", verifier.hasWarnings());
 		assertEquals("Check that implementation should have 1 warnings", 1, verifier.getWarnings().size());
-		
+
 		Issue warnIssue = verifier.getWarnings().iterator().next();
 		TestHelper.verifyIssue(IssueLocation.SOURCE, IssueSeverity.WARNING, IssueType.DIFFERENT, ActionResponseBodySchemaChecker.RESPONSE_BODY_FIELDDIFFERENT, "element2 : POST /base/endpointWithResponseType", warnIssue);
-		
+
 	}
-	
+
+
 	@Test
 	public void test_ActionContentTypeChecker_ErrorMissingFieldInRaml() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-responsebody-missing.raml");
-		Class<?>[] classesToGenerate = new Class[] {ResponseBodyTestController.class};
+		Class<?>[] classesToGenerate = new Class[] { ResponseBodyTestController.class };
 		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-		
+
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionResponseBodySchemaChecker()), null);
 		assertTrue("Check that there are errors", verifier.hasErrors());
 		assertFalse("Check that there are warnings", verifier.hasWarnings());
 		assertEquals("Check that implementation should have 1 errors", 1, verifier.getErrors().size());
-		
+
 		Issue errorIssue = verifier.getErrors().iterator().next();
 		TestHelper.verifyIssue(IssueLocation.CONTRACT, IssueSeverity.ERROR, IssueType.MISSING, ActionResponseBodySchemaChecker.RESPONSE_BODY_FIELDMISSING, "element3 : POST /base/endpointWithResponseType", errorIssue);
-		
+
 	}
-	
+
+
 	@Test
 	public void test_ActionContentTypeChecker_ErrorMissingFieldInSource() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-responsebody-success.raml");
-		Class<?>[] classesToGenerate = new Class[] {ResponseBodyTestControllerError.class};
+		Class<?>[] classesToGenerate = new Class[] { ResponseBodyTestControllerError.class };
 		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-		
+
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionResponseBodySchemaChecker()), null);
 		assertTrue("Check that there are errors", verifier.hasErrors());
 		assertFalse("Check that there are warnings", verifier.hasWarnings());
 		assertEquals("Check that implementation should have 1 errors", 1, verifier.getErrors().size());
-		
+
 		Issue errorIssue = verifier.getErrors().iterator().next();
 		TestHelper.verifyIssue(IssueLocation.SOURCE, IssueSeverity.ERROR, IssueType.MISSING, ActionResponseBodySchemaChecker.RESPONSE_BODY_FIELDMISSING, "element3 : POST /base/endpointWithResponseType", errorIssue);
-		
+
 	}
-	
-	
+
+
 	@Test
 	public void test_ActionQueryParameterChecker_SuccessWithPostWarning() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-queryparam-success.raml");
-		Class<?>[] classesToGenerate = new Class[] {ParamTestController.class, ParamTestControllerPostWarning.class};
+		Class<?>[] classesToGenerate = new Class[] { ParamTestController.class, ParamTestControllerPostWarning.class };
 		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-		
+
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionQueryParameterChecker()), null);
 		assertFalse("Check that there are no errors and implementation matches raml", verifier.hasErrors());
 		assertTrue("Check that there are warnings", verifier.hasWarnings());
 		assertEquals("Check that implementation shuld have 2 warnings", 2, verifier.getWarnings().size());
 		TestHelper.verifyIssuesUnordered(verifier.getWarnings(), new Issue[] {
-			new Issue(IssueSeverity.WARNING, IssueLocation.SOURCE, IssueType.MISSING, ActionQueryParameterChecker.QUERY_PARAMETER_FOUND_IN_FORM, "param5 : POST /base/endpointWithURIParam/{uriParam}"),
-			new Issue(IssueSeverity.WARNING, IssueLocation.SOURCE, IssueType.MISSING, ActionQueryParameterChecker.QUERY_PARAMETER_FOUND_IN_FORM, "param6 : POST /base/endpointWithURIParam/{uriParam}")});
-		
-		
+				new Issue(IssueSeverity.WARNING, IssueLocation.SOURCE, IssueType.MISSING, ActionQueryParameterChecker.QUERY_PARAMETER_FOUND_IN_FORM, "param5 : POST /base/endpointWithURIParam/{uriParam}"),
+				new Issue(IssueSeverity.WARNING, IssueLocation.SOURCE, IssueType.MISSING, ActionQueryParameterChecker.QUERY_PARAMETER_FOUND_IN_FORM, "param6 : POST /base/endpointWithURIParam/{uriParam}") });
+
+
 	}
-	
-	
-	
+
+
 	@Test
 	public void test_ActionQueryParameterChecker_MissingParamsInContract() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-queryparam-missing.raml");
-		Class<?>[] classesToGenerate = new Class[] {ParamTestController.class};
+		Class<?>[] classesToGenerate = new Class[] { ParamTestController.class };
 		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-		
+
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionQueryParameterChecker()), null);
 		assertTrue("Check that there are errors", verifier.hasErrors());
 		assertTrue("Check that there are warnings", verifier.hasWarnings());
 		assertEquals("Check that implementation should have 1 warnings", 1, verifier.getWarnings().size());
 		assertEquals("Check that implementation should have 1 errors", 1, verifier.getErrors().size());
-		
+
 		Issue warnIssue = verifier.getWarnings().iterator().next();
 		TestHelper.verifyIssue(IssueLocation.CONTRACT, IssueSeverity.WARNING, IssueType.MISSING, ActionQueryParameterChecker.QUERY_PARAMETER_MISSING, "param4 : GET /base/endpointWithURIParam/{uriParam}", warnIssue);
-		
+
 		Issue errorIssue = verifier.getErrors().iterator().next();
 		TestHelper.verifyIssue(IssueLocation.CONTRACT, IssueSeverity.ERROR, IssueType.MISSING, ActionQueryParameterChecker.QUERY_PARAMETER_MISSING, "param3 : GET /base/endpointWithURIParam/{uriParam}", errorIssue);
-		
+
 	}
-	
+
+
 	@Test
 	public void test_ActionQueryParameterChecker_MissingParamsInSource() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-queryparam-success.raml");
-		Class<?>[] classesToGenerate = new Class[] {ParamTestController.class, ParamTestControllerPostMissing.class};
+		Class<?>[] classesToGenerate = new Class[] { ParamTestController.class, ParamTestControllerPostMissing.class };
 		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-		
+
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionQueryParameterChecker()), null);
 		assertTrue("Check that there are errors", verifier.hasErrors());
 		assertFalse("Check that there are no warnings and implementation matches raml", verifier.hasWarnings());
 		assertEquals("Check that implementation should have 2 errors", 2, verifier.getErrors().size());
 		TestHelper.verifyIssuesUnordered(verifier.getErrors(), new Issue[] {
-			new Issue(IssueSeverity.ERROR, IssueLocation.SOURCE, IssueType.MISSING, ActionQueryParameterChecker.QUERY_PARAMETER_MISSING, "param5 : POST /base/endpointWithURIParam/{uriParam}"),
-			new Issue(IssueSeverity.ERROR, IssueLocation.SOURCE, IssueType.MISSING, ActionQueryParameterChecker.QUERY_PARAMETER_MISSING, "param6 : POST /base/endpointWithURIParam/{uriParam}")});
-		
-		
+				new Issue(IssueSeverity.ERROR, IssueLocation.SOURCE, IssueType.MISSING, ActionQueryParameterChecker.QUERY_PARAMETER_MISSING, "param5 : POST /base/endpointWithURIParam/{uriParam}"),
+				new Issue(IssueSeverity.ERROR, IssueLocation.SOURCE, IssueType.MISSING, ActionQueryParameterChecker.QUERY_PARAMETER_MISSING, "param6 : POST /base/endpointWithURIParam/{uriParam}") });
+
+
 	}
-	
+
+
 	@Test
 	public void test_ActionQueryParameterChecker_MissingParamsNotRequiredDowngradeToWarning() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-queryparam-success.raml");
-		Class<?>[] classesToGenerate = new Class[] {ParamTestController.class, ParamTestControllerDowngradeToWarning.class};
+		Class<?>[] classesToGenerate = new Class[] { ParamTestController.class, ParamTestControllerDowngradeToWarning.class };
 		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-		
+
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionQueryParameterChecker()), null);
 		assertTrue("Check that there are errors", verifier.hasErrors());
 		assertTrue("Check that there are warnings", verifier.hasWarnings());
 		assertEquals("Check that implementation should have 2 errors", 3, verifier.getErrors().size());
 		assertEquals("Check that implementation should have 1 warning", 1, verifier.getWarnings().size());
 		TestHelper.verifyIssuesUnordered(verifier.getErrors(), new Issue[] {
-			new Issue(IssueSeverity.ERROR, IssueLocation.SOURCE, IssueType.MISSING, ActionQueryParameterChecker.QUERY_PARAMETER_MISSING, "param5 : POST /base/endpointWithURIParam/{uriParam}"),
-			new Issue(IssueSeverity.ERROR, IssueLocation.SOURCE, IssueType.MISSING, ActionQueryParameterChecker.QUERY_PARAMETER_MISSING, "param6 : POST /base/endpointWithURIParam/{uriParam}"),
-			new Issue(IssueSeverity.ERROR, IssueLocation.SOURCE, IssueType.MISSING, ActionQueryParameterChecker.QUERY_PARAMETER_MISSING, "param3 : GET /base/endpointWithURIParam/{uriParam}")});
-		
+				new Issue(IssueSeverity.ERROR, IssueLocation.SOURCE, IssueType.MISSING, ActionQueryParameterChecker.QUERY_PARAMETER_MISSING, "param5 : POST /base/endpointWithURIParam/{uriParam}"),
+				new Issue(IssueSeverity.ERROR, IssueLocation.SOURCE, IssueType.MISSING, ActionQueryParameterChecker.QUERY_PARAMETER_MISSING, "param6 : POST /base/endpointWithURIParam/{uriParam}"),
+				new Issue(IssueSeverity.ERROR, IssueLocation.SOURCE, IssueType.MISSING, ActionQueryParameterChecker.QUERY_PARAMETER_MISSING, "param3 : GET /base/endpointWithURIParam/{uriParam}") });
+
 		Issue warnIssue = verifier.getWarnings().iterator().next();
 		TestHelper.verifyIssue(IssueLocation.SOURCE, IssueSeverity.WARNING, IssueType.MISSING, ActionQueryParameterChecker.QUERY_PARAMETER_MISSING, "param4 : GET /base/endpointWithURIParam/{uriParam}", warnIssue);
-		
-		
+
+
 	}
-	
+
+
 	@Test
 	public void test_ActionExistenceChecker_Success() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-simple.raml");
-		Class<?>[] classesToGenerate = new Class[] {VerifierTestController.class, SecondVerifierTestController.class};
+		Class<?>[] classesToGenerate = new Class[] { VerifierTestController.class, SecondVerifierTestController.class };
 		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-		
+
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), null, Collections.singletonList(new ActionExistenceChecker()));
 		assertFalse("Check that there are no errors and implementation matches raml", verifier.hasErrors());
 		assertFalse("Check that there are no warnings and implementation matches raml", verifier.hasWarnings());
-		
+
 	}
-	
+
+
 	@Test
 	public void test_ActionExistenceChecker_MissingAndExtraActions() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-actions-missing.raml");
-		Class<?>[] classesToGenerate = new Class[] {VerifierTestController.class, SecondVerifierTestController.class};
+		Class<?>[] classesToGenerate = new Class[] { VerifierTestController.class, SecondVerifierTestController.class };
 		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-		
+
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), null, Collections.singletonList(new ActionExistenceChecker()));
 		assertTrue("Check that there are no errors and implementation matches raml", verifier.hasErrors());
 		assertEquals("Check that implementation shuld have 1 errors", 1, verifier.getErrors().size());
 		Issue errorIssue = verifier.getErrors().iterator().next();
 		TestHelper.verifyIssue(IssueLocation.SOURCE, IssueSeverity.ERROR, IssueType.MISSING, ActionExistenceChecker.ACTION_MISSING, "POST /secondBase/endpointWithURIParam/{uriParam}", errorIssue);
-		
-		
-		
+
+
 		assertTrue("Check that there are no warnings and implementation matches raml", verifier.hasWarnings());
 		assertEquals("Check that implementation shuld have 2 warnings", 2, verifier.getWarnings().size());
 		TestHelper.verifyIssuesUnordered(verifier.getWarnings(), new Issue[] {
-			new Issue(IssueSeverity.WARNING, IssueLocation.CONTRACT, IssueType.MISSING, ActionExistenceChecker.ACTION_MISSING, "GET /base/endpointWithGetAndPost"),
-			new Issue(IssueSeverity.WARNING, IssueLocation.CONTRACT, IssueType.MISSING, ActionExistenceChecker.ACTION_MISSING, "POST /base/endpointWithGetAndPost")});
-		
+				new Issue(IssueSeverity.WARNING, IssueLocation.CONTRACT, IssueType.MISSING, ActionExistenceChecker.ACTION_MISSING, "GET /base/endpointWithGetAndPost"),
+				new Issue(IssueSeverity.WARNING, IssueLocation.CONTRACT, IssueType.MISSING, ActionExistenceChecker.ACTION_MISSING, "POST /base/endpointWithGetAndPost") });
+
 	}
-	
+
+
 	@Test
 	public void test_ResourceExistenceChecker_MissingResourceInRaml() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-simple.raml");
-		Class<?>[] classesToGenerate = new Class[] {VerifierTestController.class, SecondVerifierTestController.class, ThirdVerifierTestController.class};
+		Class<?>[] classesToGenerate = new Class[] { VerifierTestController.class, SecondVerifierTestController.class, ThirdVerifierTestController.class };
 		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-		
+
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.singletonList(new ResourceExistenceChecker()), null, null);
 		assertFalse("Check that there are no errors since the missing resource will get marked as a warning", verifier.hasErrors());
 		assertTrue("Check that there are warnings since there are more resources implemented than declared in raml", verifier.hasWarnings());
 		assertEquals("Check that implementation should have 1 warnings", 1, verifier.getWarnings().size());
 		Iterator<Issue> iterator = verifier.getWarnings().iterator();
 		TestHelper.verifyIssue(IssueLocation.CONTRACT, IssueSeverity.WARNING, IssueType.MISSING, ResourceExistenceChecker.RESOURCE_MISSING, "/thirdBase", iterator.next());
-		
+
 	}
-	
+
+
 	@Test
 	public void test_ResourceExistenceChecker_MissingResourceInImplementation() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-simple.raml");
-		Class<?>[] classesToGenerate = new Class[] {VerifierTestController.class};
+		Class<?>[] classesToGenerate = new Class[] { VerifierTestController.class };
 		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-		
+
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.singletonList(new ResourceExistenceChecker()), null, null);
 		assertTrue("Check that there are errors since there is part of our contract not implemented", verifier.hasErrors());
 		assertEquals("Check that implementation should have 1 error", 1, verifier.getErrors().size());
 		Iterator<Issue> iterator = verifier.getErrors().iterator();
 		TestHelper.verifyIssue(IssueLocation.SOURCE, IssueSeverity.ERROR, IssueType.MISSING, ResourceExistenceChecker.RESOURCE_MISSING, "/secondBase", iterator.next());
 		assertFalse("Check that there are no warnings", verifier.hasWarnings());
-		
+
 	}
-	
+
+
 	@Test
 	public void test_ResourceExistenceChecker_UriParamAlwaysWarning() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-uriparam.raml");
-		Class<?>[] classesToGenerate = new Class[] {SecondVerifierTestController.class};
+		Class<?>[] classesToGenerate = new Class[] { SecondVerifierTestController.class };
 		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-		
+
 		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.singletonList(new ResourceExistenceChecker()), null, null);
 		assertFalse("Check that there are no errors", verifier.hasErrors());
 		assertTrue("Check that there is warning for UriParam", verifier.hasWarnings());
 		assertEquals("Check that implementation should have 2 warnings", 2, verifier.getWarnings().size());
 		TestHelper.verifyIssuesUnordered(verifier.getWarnings(), new Issue[] {
-			new Issue(IssueSeverity.WARNING, IssueLocation.SOURCE, IssueType.MISSING, ResourceExistenceChecker.RESOURCE_MISSING, "/secondBase/endpointWithURIParam/{differentNameParam}"),
-			new Issue(IssueSeverity.WARNING, IssueLocation.CONTRACT, IssueType.MISSING, ResourceExistenceChecker.RESOURCE_MISSING, "/secondBase/endpointWithURIParam/{uriParam}")});
+				new Issue(IssueSeverity.WARNING, IssueLocation.SOURCE, IssueType.MISSING, ResourceExistenceChecker.RESOURCE_MISSING, "/secondBase/endpointWithURIParam/{differentNameParam}"),
+				new Issue(IssueSeverity.WARNING, IssueLocation.CONTRACT, IssueType.MISSING, ResourceExistenceChecker.RESOURCE_MISSING, "/secondBase/endpointWithURIParam/{uriParam}") });
 	}
 
 }

--- a/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/RamlVerifierTest.java
+++ b/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/RamlVerifierTest.java
@@ -130,19 +130,6 @@ public class RamlVerifierTest {
 
 
 	@Test
-	public void test_ActionMultiContentTypeChecker_ExtraContentTypeInController() {
-		Raml published = RamlVerifier.loadRamlFromFile("test-multicontenttype-missingcontent.raml");
-		Class<?>[] classesToGenerate = new Class[] { MultiContentTypeTestController.class };
-		Raml computed = generator.generateRamlForClasses("test", "0.0.1", "/", classesToGenerate, Collections.emptySet()).getRaml();
-
-		RamlVerifier verifier = new RamlVerifier(published, computed, Collections.emptyList(), Collections.singletonList(new ActionContentTypeChecker()), null);
-		assertTrue("Check that there are no errors and implementation matches raml", verifier.hasErrors());
-		assertFalse("Check that there are no warnings and implementation matches raml", verifier.hasWarnings());
-
-	}
-
-
-	@Test
 	public void test_ActionResponseBodySchemaChecker_Success() {
 		Raml published = RamlVerifier.loadRamlFromFile("test-responsebody-success.raml");
 		Class<?>[] classesToGenerate = new Class[] { ResponseBodyTestController.class };

--- a/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/Spring4ControllerDecoratorTest.java
+++ b/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/Spring4ControllerDecoratorTest.java
@@ -42,6 +42,7 @@ public class Spring4ControllerDecoratorTest {
             verifyGenerateClassFor(apiControllerMetadata);
         }
     }
+    
 
     @Test
     public void test_contenttype_decorator_Success() throws Exception {

--- a/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/SpringMvcResourceParserTest.java
+++ b/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/SpringMvcResourceParserTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Method;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -47,6 +48,7 @@ import test.phoenixnap.oss.plugin.naming.testclasses.NoValueController;
 import test.phoenixnap.oss.plugin.naming.testclasses.TestController;
 
 import com.phoenixnap.oss.ramlapisync.data.ApiControllerMetadata;
+import com.phoenixnap.oss.ramlapisync.data.ApiMappingMetadata;
 import com.phoenixnap.oss.ramlapisync.generation.RamlParser;
 import com.phoenixnap.oss.ramlapisync.generation.RamlVerifier;
 import com.phoenixnap.oss.ramlapisync.javadoc.JavaDocEntry;
@@ -88,13 +90,29 @@ public class SpringMvcResourceParserTest {
 	}
 	
     @Test
-    public void test_seperateContentType_decorator_Success() throws Exception {
+    public void test_seperateContentType__Success() throws Exception {
         Raml published = RamlVerifier.loadRamlFromFile("test-responsebody-multipletype.raml");
-        RamlParser par = new RamlParser("com.gen.test", "/api");
+        RamlParser par = new RamlParser("com.gen.test", "/api", true);
         Set<ApiControllerMetadata> controllersMetadataSet = par.extractControllers(published);
 
         assertEquals(1, controllersMetadataSet.size());
         assertEquals(2, controllersMetadataSet.iterator().next().getApiCalls().size());
+        
+        //lets check that names wont collide
+        Iterator<ApiMappingMetadata> apiCallIterator = controllersMetadataSet.iterator().next().getApiCalls().iterator();
+		assertTrue(apiCallIterator.next().getName().contains("As"));
+		assertTrue(apiCallIterator.next().getName().contains("As"));
+        
+        //lets check that it switches off correctly
+        par = new RamlParser("com.gen.test", "/api", false);
+        controllersMetadataSet = par.extractControllers(published);
+        assertEquals(1, controllersMetadataSet.size());
+        assertEquals(1, controllersMetadataSet.iterator().next().getApiCalls().size());
+        
+        //lets check that names arent changed
+        apiCallIterator = controllersMetadataSet.iterator().next().getApiCalls().iterator();
+		assertFalse(apiCallIterator.next().getName().contains("As"));
+		
 
     }
 

--- a/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/SpringMvcResourceParserTest.java
+++ b/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/SpringMvcResourceParserTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -31,6 +32,7 @@ import org.raml.model.Action;
 import org.raml.model.ActionType;
 import org.raml.model.MimeType;
 import org.raml.model.ParamType;
+import org.raml.model.Raml;
 import org.raml.model.Resource;
 import org.raml.model.Response;
 import org.raml.model.parameter.FormParameter;
@@ -44,6 +46,9 @@ import test.phoenixnap.oss.plugin.naming.testclasses.BugController;
 import test.phoenixnap.oss.plugin.naming.testclasses.NoValueController;
 import test.phoenixnap.oss.plugin.naming.testclasses.TestController;
 
+import com.phoenixnap.oss.ramlapisync.data.ApiControllerMetadata;
+import com.phoenixnap.oss.ramlapisync.generation.RamlParser;
+import com.phoenixnap.oss.ramlapisync.generation.RamlVerifier;
 import com.phoenixnap.oss.ramlapisync.javadoc.JavaDocEntry;
 import com.phoenixnap.oss.ramlapisync.javadoc.JavaDocExtractor;
 import com.phoenixnap.oss.ramlapisync.javadoc.JavaDocStore;
@@ -81,6 +86,17 @@ public class SpringMvcResourceParserTest {
 		assertNotNull("Check Response is there", response.getBody().get(DEFAULT_MEDIA_TYPE));
 		assertNotNull("Check Response Schema is there", response.getBody().get(DEFAULT_MEDIA_TYPE).getSchema());
 	}
+	
+    @Test
+    public void test_seperateContentType_decorator_Success() throws Exception {
+        Raml published = RamlVerifier.loadRamlFromFile("test-responsebody-multipletype.raml");
+        RamlParser par = new RamlParser("com.gen.test", "/api");
+        Set<ApiControllerMetadata> controllersMetadataSet = par.extractControllers(published);
+
+        assertEquals(1, controllersMetadataSet.size());
+        assertEquals(2, controllersMetadataSet.iterator().next().getApiCalls().size());
+
+    }
 
 	private static String combineConstantAndName(String constant, String name) {
 		return name + constant;

--- a/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/SpringMvcResourceParserTest.java
+++ b/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/SpringMvcResourceParserTest.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -57,6 +56,7 @@ import com.phoenixnap.oss.ramlapisync.javadoc.JavaDocEntry;
 import com.phoenixnap.oss.ramlapisync.javadoc.JavaDocExtractor;
 import com.phoenixnap.oss.ramlapisync.javadoc.JavaDocStore;
 import com.phoenixnap.oss.ramlapisync.parser.FileSearcher;
+import com.phoenixnap.oss.ramlapisync.parser.ResourceParser;
 import com.phoenixnap.oss.ramlapisync.parser.SpringMvcResourceParser;
 
 /**
@@ -84,7 +84,7 @@ public class SpringMvcResourceParserTest {
 
 	private void validateSimpleAjaxResponse(Action action) {
 		assertEquals(1, action.getResponses().size());
-		Response response = action.getResponses().get("200");
+		Response response = ResourceParser.getSuccessfulResponse(action);
 		assertEquals("Checking return javadoc", RETURN_JAVADOC, response.getDescription());
 		assertEquals(1, response.getBody().size());
 		assertNotNull("Check Response is there", response.getBody().get(DEFAULT_MEDIA_TYPE));
@@ -93,7 +93,7 @@ public class SpringMvcResourceParserTest {
 	
 	private void validateMultipleResponse(Action action) {
 		assertEquals(1, action.getResponses().size());
-		Response response = action.getResponses().get("200");
+		Response response = ResourceParser.getSuccessfulResponse(action);
 		assertEquals("Checking return javadoc", RETURN_JAVADOC, response.getDescription());
 		assertEquals(2, response.getBody().size());
 		assertNotNull("Check Response is there", response.getBody().get(MediaType.APPLICATION_JSON_VALUE));		

--- a/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/SpringMvcResourceParserTest.java
+++ b/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/SpringMvcResourceParserTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -44,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 
 import test.phoenixnap.oss.plugin.naming.testclasses.BugController;
+import test.phoenixnap.oss.plugin.naming.testclasses.MultipleContentTypeTestController;
 import test.phoenixnap.oss.plugin.naming.testclasses.NoValueController;
 import test.phoenixnap.oss.plugin.naming.testclasses.TestController;
 
@@ -89,35 +91,13 @@ public class SpringMvcResourceParserTest {
 		assertNotNull("Check Response Schema is there", response.getBody().get(DEFAULT_MEDIA_TYPE).getSchema());
 	}
 	
-    @Test
-    public void test_seperateContentType__Success() throws Exception {
-        Raml published = RamlVerifier.loadRamlFromFile("test-responsebody-multipletype.raml");
-        RamlParser par = new RamlParser("com.gen.test", "/api", true);
-        Set<ApiControllerMetadata> controllersMetadataSet = par.extractControllers(published);
-
-        assertEquals(1, controllersMetadataSet.size());
-        assertEquals(2, controllersMetadataSet.iterator().next().getApiCalls().size());
-        
-        //lets check that names wont collide
-        Iterator<ApiMappingMetadata> apiCallIterator = controllersMetadataSet.iterator().next().getApiCalls().iterator();
-		assertTrue(apiCallIterator.next().getName().contains("As"));
-		assertTrue(apiCallIterator.next().getName().contains("As"));
-        
-        //lets check that it switches off correctly
-        par = new RamlParser("com.gen.test", "/api", false);
-        controllersMetadataSet = par.extractControllers(published);
-        assertEquals(1, controllersMetadataSet.size());
-        assertEquals(1, controllersMetadataSet.iterator().next().getApiCalls().size());
-        
-        //lets check that names arent changed
-        apiCallIterator = controllersMetadataSet.iterator().next().getApiCalls().iterator();
-		assertFalse(apiCallIterator.next().getName().contains("As"));
-		
-
-    }
-
-	private static String combineConstantAndName(String constant, String name) {
-		return name + constant;
+	private void validateMultipleResponse(Action action) {
+		assertEquals(1, action.getResponses().size());
+		Response response = action.getResponses().get("200");
+		assertEquals("Checking return javadoc", RETURN_JAVADOC, response.getDescription());
+		assertEquals(2, response.getBody().size());
+		assertNotNull("Check Response is there", response.getBody().get(MediaType.APPLICATION_JSON_VALUE));		
+		assertNotNull("Check Response is there", response.getBody().get(MediaType.TEXT_PLAIN_VALUE));		
 	}
 
 	@SuppressWarnings("unchecked")
@@ -151,6 +131,39 @@ public class SpringMvcResourceParserTest {
 
 		baseResourceTestController = parser.extractResourceInfo(TestController.class);
 	}
+	
+
+	private static String combineConstantAndName(String constant, String name) {
+		return name + constant;
+	}
+
+    @Test
+    public void test_seperateContentType__Success() throws Exception {
+        Raml published = RamlVerifier.loadRamlFromFile("test-responsebody-multipletype.raml");
+        RamlParser par = new RamlParser("com.gen.test", "/api", true);
+        Set<ApiControllerMetadata> controllersMetadataSet = par.extractControllers(published);
+
+        assertEquals(1, controllersMetadataSet.size());
+        assertEquals(2, controllersMetadataSet.iterator().next().getApiCalls().size());
+        
+        //lets check that names wont collide
+        Iterator<ApiMappingMetadata> apiCallIterator = controllersMetadataSet.iterator().next().getApiCalls().iterator();
+		assertTrue(apiCallIterator.next().getName().contains("As"));
+		assertTrue(apiCallIterator.next().getName().contains("As"));
+        
+        //lets check that it switches off correctly
+        par = new RamlParser("com.gen.test", "/api", false);
+        controllersMetadataSet = par.extractControllers(published);
+        assertEquals(1, controllersMetadataSet.size());
+        assertEquals(1, controllersMetadataSet.iterator().next().getApiCalls().size());
+        
+        //lets check that names arent changed
+        apiCallIterator = controllersMetadataSet.iterator().next().getApiCalls().iterator();
+		assertFalse(apiCallIterator.next().getName().contains("As"));
+		
+
+    }
+
 
 	@Test
 	public void test_controllerdetection() {
@@ -164,6 +177,22 @@ public class SpringMvcResourceParserTest {
 	public void test_multipleHttpMethods() {
 		Resource testResource = baseResourceTestController.getResource("/base").getResource("/simpleMethodAll");
 		assertEquals("Assert resources size", ActionType.values().length, testResource.getActions().size());
+	}
+	
+	@Test
+	public void test_multipleContentType() {
+		Resource resourceInfo = parser.extractResourceInfo(MultipleContentTypeTestController.class);
+
+		Resource testResource = resourceInfo.getResource("/base").getResource("/endpoint");
+		assertEquals("Assert resources size", 2, testResource.getActions().size());
+		Action getAction = testResource.getActions().get(ActionType.GET);
+		Action postAction = testResource.getActions().get(ActionType.POST);
+		assertNotNull(getAction);
+		assertNotNull(postAction);
+		assertEquals("Assert Javadoc", COMMENT_JAVADOC, getAction.getDescription());
+		assertEquals("Assert Javadoc", COMMENT_JAVADOC, postAction.getDescription());
+		validateMultipleResponse(getAction);
+		validateMultipleResponse(postAction);
 	}
 
 	@Test

--- a/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/testclasses/MultiContentTypeTestController.java
+++ b/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/testclasses/MultiContentTypeTestController.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package test.phoenixnap.oss.plugin.naming.testclasses;
+
+
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+
+
+/**
+ * 
+ * Test Class
+ * 
+ * @author Kurt Paris
+ * @since 0.1.0
+ *
+ */
+@RestController
+public class MultiContentTypeTestController {
+
+	public void unannotatedMethod() {
+
+	}
+
+
+	@RequestMapping(value = "/base/endpointWithNoContentType", method = { RequestMethod.GET })
+	public String endpointWithNoContentType() {
+		return null;
+	}
+
+
+	@RequestMapping(value = "/base/endpointWithRequestType", method = { RequestMethod.POST })
+	public String endpointWithRequestType(@RequestBody ThreeElementClass request) {
+		return null;
+	}
+
+
+	@RequestMapping(value = "/base/endpointWithRequestAndResponseType", method = { RequestMethod.POST })
+	public @ResponseBody ThreeElementClass endpointWithRequestAndResponseType(@RequestBody ThreeElementClass request) {
+		return null;
+	}
+
+
+	@RequestMapping(value = "/base/endpointWithResponseType", method = { RequestMethod.POST }, produces = "text/html")
+	public @ResponseBody String endpointWithResponseType() {
+		return "";
+	}
+
+
+	@RequestMapping(value = "/base/endpointWithResponseType", method = { RequestMethod.POST }, produces = "application/json")
+	public @ResponseBody ThreeElementClass endpointWithDifferentResponseType() {
+		return null;
+	}
+
+
+}

--- a/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/testclasses/MultipleContentTypeTestController.java
+++ b/springmvc-raml-parser/src/test/java/test/phoenixnap/oss/plugin/naming/testclasses/MultipleContentTypeTestController.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package test.phoenixnap.oss.plugin.naming.testclasses;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 
+ * Test Class
+ * 
+ * @author Kurt Paris
+ * @since 0.3.1
+ *
+ */
+@RestController
+public class MultipleContentTypeTestController {
+
+	public void unannotatedMethod() {
+
+	}
+
+	@RequestMapping(value = "/base/endpoint", method = { RequestMethod.GET}, produces={ MediaType.APPLICATION_JSON_VALUE})
+	public String endpoint() {
+		return null;
+	}
+	
+	@RequestMapping(value = "/base/endpoint", method = { RequestMethod.GET}, produces={ MediaType.TEXT_PLAIN_VALUE})
+	public String endpointAgain(@RequestBody ThreeElementClass request) {
+		return null;
+	}
+	
+	@RequestMapping(value = "/base/endpoint", method = { RequestMethod.POST}, produces={ MediaType.APPLICATION_JSON_VALUE})
+	public String secondEndpoint() {
+		return null;
+	}
+	
+	@RequestMapping(value = "/base/endpoint", method = { RequestMethod.POST}, produces={ MediaType.TEXT_PLAIN_VALUE})
+	public String secondEndpointAgain(@RequestBody ThreeElementClass request) {
+		return null;
+	}
+	
+	
+
+}

--- a/springmvc-raml-parser/src/test/resources/test-multicontenttype-missingcontent.raml
+++ b/springmvc-raml-parser/src/test/resources/test-multicontenttype-missingcontent.raml
@@ -1,0 +1,58 @@
+#%RAML 0.8
+title: myapi
+baseUri: /
+version: 1
+
+/base:
+  /endpointWithNoContentType:
+    get:
+      queryParameters:
+        param1:
+          required: true
+        param2:
+  /endpointWithRequestType:
+    post:
+      body:
+        application/json:
+          schema: |
+            {
+              "type": "object",
+              "$schema": "http://json-schema.org/draft-03/schema",
+              "id": "http://jsonschema.net",
+              "required": true
+            }
+  /endpointWithRequestAndResponseType:
+    post:
+      body:
+        application/json:
+          schema: |
+            {
+              "type": "object",
+              "$schema": "http://json-schema.org/draft-03/schema",
+              "id": "http://jsonschema.net",
+              "required": true
+            }
+      responses:
+        200:
+          body:
+            application/everything:
+              schema: |
+                {
+                  "type": "object",
+                  "$schema": "http://json-schema.org/draft-03/schema",
+                  "id": "http://jsonschema.net",
+                  "required": true
+                }
+  /endpointWithResponseType:
+    post:      
+      responses:
+        200:
+          body:
+            application/json:
+              schema: |
+                {
+                  "type": "object",
+                  "$schema": "http://json-schema.org/draft-03/schema",
+                  "id": "http://jsonschema.net",
+                  "required": true
+                }           

--- a/springmvc-raml-parser/src/test/resources/test-multicontenttype-success.raml
+++ b/springmvc-raml-parser/src/test/resources/test-multicontenttype-success.raml
@@ -1,0 +1,63 @@
+#%RAML 0.8
+title: myapi
+baseUri: /
+version: 1
+
+/base:
+  /endpointWithNoContentType:
+    get:
+      queryParameters:
+        param1:
+          required: true
+        param2:
+  /endpointWithRequestType:
+    post:
+      body:
+        application/json:
+          schema: |
+            {
+              "type": "object",
+              "$schema": "http://json-schema.org/draft-03/schema",
+              "id": "http://jsonschema.net",
+              "required": true
+            }
+  /endpointWithRequestAndResponseType:
+    post:
+      body:
+        application/json:
+          schema: |
+            {
+              "type": "object",
+              "$schema": "http://json-schema.org/draft-03/schema",
+              "id": "http://jsonschema.net",
+              "required": true
+            }
+      responses:
+        200:
+          body:
+            application/everything:
+              schema: |
+                {
+                  "type": "object",
+                  "$schema": "http://json-schema.org/draft-03/schema",
+                  "id": "http://jsonschema.net",
+                  "required": true
+                }
+  /endpointWithResponseType:
+    post:      
+      responses:
+        200:
+          body:
+            application/json:
+              schema: |
+                {
+                  "type": "object",
+                  "$schema": "http://json-schema.org/draft-03/schema",
+                  "id": "http://jsonschema.net",
+                  "required": true
+                }
+            text/html:
+              schema: |
+                {
+                  "type": "string",                 
+                }

--- a/springmvc-raml-parser/src/test/resources/test-responsebody-multipletype.raml
+++ b/springmvc-raml-parser/src/test/resources/test-responsebody-multipletype.raml
@@ -1,0 +1,40 @@
+#%RAML 0.8
+title: myapi
+baseUri: /
+version: 1
+
+/base:
+  /endpointWithResponseType:
+    post:      
+      responses:
+        200:
+          body:
+            application/test+json:
+              schema: |
+                {
+                  "type":"object",
+                  "properties": {
+                    "element1": {
+                      "type": "integer"
+                    },
+                    "element2": {
+                      "type": "string"
+                    },
+                    "element3": {
+                      "type": "string"
+                    }
+                  }
+                }
+            application/othertest+json:
+              schema: |
+                {
+                  "type":"object",
+                  "properties": {
+                    "element4": {
+                      "type": "integer"
+                    },
+                    "element5": {
+                      "type": "string"
+                    }
+                  }
+                }

--- a/springmvc-raml-plugin/README.md
+++ b/springmvc-raml-plugin/README.md
@@ -207,6 +207,7 @@ Then simply include the following code in the POM of the project you wish to gen
     <addTimestampFolder>false</addTimestampFolder>
     <basePackage>com.gen.wow</basePackage>
     <baseUri>/api</baseUri>
+	<seperateMethodsByContentType>false</seperateMethodsByContentType>
   </configuration>
   <executions>
     <execution>
@@ -237,6 +238,9 @@ Then simply include the following code in the POM of the project you wish to gen
 
 ### ramlGenerator
 (optional, default: com.phoenixnap.oss.ramlapisync.generation.RamlGenerator) The generator class to be used. 
+
+### seperateMethodsByContentType
+(optional, default: false) Should we generate seperate API methods for endpoints which define multiple content types in their 200 response. 
 
 - com.phoenixnap.oss.ramlapisync.generation.RamlGenerator: 
 The standard generator. It creates simple controller stubs classes with Spring MVC annotations and empty method bodies (like in v.0.2.4).

--- a/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/SpringMvcEndpointGeneratorMojo.java
+++ b/springmvc-raml-plugin/src/main/java/com/phoenixnap/oss/ramlapisync/plugin/SpringMvcEndpointGeneratorMojo.java
@@ -87,6 +87,12 @@ public class SpringMvcEndpointGeneratorMojo extends AbstractMojo {
 	 */
 	@Parameter(required = false, readonly = true)
 	protected String baseUri;
+	
+	/**
+	 * If set to true, we will generate seperate methods for different content types in the RAML
+	 */
+	@Parameter(required = false, readonly = true, defaultValue = "false")
+	protected Boolean seperateMethodsByContentType;
 
 	/**
 	 * The full qualified name of the RamlGenerator that should be used.
@@ -110,7 +116,7 @@ public class SpringMvcEndpointGeneratorMojo extends AbstractMojo {
 		}
 		
 		Raml loadRamlFromFile = RamlParser.loadRamlFromFile( "file:"+resolvedRamlPath );
-		RamlParser par = new RamlParser(basePackage, getBasePath(loadRamlFromFile));
+		RamlParser par = new RamlParser(basePackage, getBasePath(loadRamlFromFile), seperateMethodsByContentType);
 		RamlGenerator gen = createRamlGenerator();
 		Set<ApiControllerMetadata> controllers = par.extractControllers(loadRamlFromFile);
 


### PR DESCRIPTION
The `RamlGenerator.generateClassForRaml(..)` method becomes obsolete.
My idea is to use instances of `com.phoenixnap.oss.ramlapisync.generation.rules.Rule` instead.
At the top level we have three rules that operates on top of a `JCodeModel`and a `ApiControllerMetadata`instance. These top level rules are plugged together out of more low level `Rule`instances, each one concerning another part of the generated artefact (e.g. package declaration, class declaration, class annotations, comments, method signatures, parameters ....).

I wrote a bunch of tests as well.

Finally I created a new maven parameter where the user can configure, which code generation rule should be used.

It should be easy for you to create completely new code generation rules to support older Spring-Versions or whatever.
